### PR TITLE
fix the style of extending methods

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,10 +75,15 @@ considered it must meet the following guidelines.
   * Separate logical blocks of code with one blank line, or two blank lines for
     function/type definitions.
 
-  * When extending method definitions, explicitly import the method.
+  * When extending method definitions, define the methods with a module name
+    prefix. E.g.
 
     ```julia
-    import Base: start, next, done
+    function Base.start(iter::YourType)
+        ...
+    end
+    
+    Base.done(iter::YourType, state) = ...
     ```
 
   * Document functions using bare docstrings before a definition:


### PR DESCRIPTION
I think we have settled in the style of prefixing a module name when extending methods.
If you agree with me, please merge this pull request. Then I will close https://github.com/BioJulia/Bio.jl/issues/96.