### PR TITLE
Package maintenance status badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - An example CHANGELOG file for all BioJulia projects.
 - An issue template.
 - A file with a statement on etiquette and conduct.
+- A section on package maintenance status badges.
 
 ### Changed
 - Contributing site generated from the symbolically linked files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ This document contains information relevant to people who want to contribute to 
 * [Making a pull request](#making-a-pull-request)
 * [Becoming a package maintainer](#becoming-a-package-maintainer)
 * [Creating a new repository under BioJulia](#creating-a-new-biojulia-repository)
+* [Package maintenance status](#package-maintenance-status)
 
 ## Contact information
 If you have questions about specific repositories, contact the repository maintainers.
@@ -80,3 +81,47 @@ This implies:
 * Other BioJulia members may be added as maintainers if you become unreachable.
 
 If the BioJulia admins agree to transfer your repo to BioJulia, we will collaborate with you to ensure the code quality, code licensing, documentation, and continuous integration of the package is up to BioJulia standards.
+
+## Package maintenance status
+BioJulia packages carry a badge in their README stating how actively the package is maintained.
+The purpose of the badge is to set expectations: it tells a prospective user whether they can rely on the package, and whether they can expect a response if they open an issue.
+
+There are three statuses:
+
+### Maintained
+<!-- badge markdown TBD -->
+
+At least one person considers themselves an active maintainer of the package.
+A user can expect their issues and pull requests to be answered.
+
+### Functional; Maintainer needed
+<!-- badge markdown TBD -->
+
+The package is expected to work, but is currently looking for a maintainer.
+A user cannot be sure that issues and pull requests will be answered, in particular not the more technical ones.
+
+### Deprecated
+<!-- badge markdown TBD -->
+
+The package is no longer modern, either because it does not work on recent Julia releases, or because it has been superseded by other Julia packages.
+New users should generally look elsewhere.
+
+### Using the badges
+To use a badge, place it near the top of your package's README, and copy the markdown for the status that applies.
+
+To be eligible for a badge, the repository must live in the [BioJulia](https://github.com/BioJulia), [JuliaHealth](https://github.com/JuliaHealth) or [EcoJulia](https://github.com/EcoJulia) GitHub organization, or in another GitHub organization approved by the BioJulia admins — for example a lab organization.
+Personal repositories are not eligible.
+This is so that the status can be updated by someone else if the maintainer becomes unreachable, for whatever reason.
+
+### Changing the status of a package
+Anyone can propose a status change by opening an issue or a pull request on the repository in question.
+If a maintainer is around, the change is simply theirs to make.
+
+If no maintainer responds:
+* After roughly **one month** of no response, the status may be changed if there is a compelling reason to do so.
+* After **six months** of no response, the status may be changed without any particular reason.
+
+If a maintainer later reappears, the status can always be changed back.
+
+It is not possible to write down rules that cover every case, so please try to work it out in the spirit of the descriptions above.
+If there is disagreement, the decision of the admins of the organization the repository belongs to should be followed, together with the [BioJulia admins](#contact-information) if the repository is outside BioJulia.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ This implies:
 If the BioJulia admins agree to transfer your repo to BioJulia, we will collaborate with you to ensure the code quality, code licensing, documentation, and continuous integration of the package is up to BioJulia standards.
 
 ## Package maintenance status
-BioJulia packages carry a badge in their README stating how actively the package is maintained.
+We recommend that every BioJulia package carries a badge at the top of its README, stating how actively the package is maintained.
 The purpose of the badge is to set expectations: it tells a prospective user whether they can rely on the package, and whether they can expect a response if they open an issue.
 
 There are three statuses:
@@ -97,31 +97,32 @@ A user can expect their issues and pull requests to be answered.
 ### Functional; Maintainer needed
 <!-- badge markdown TBD -->
 
-The package is expected to work, but is currently looking for a maintainer.
-A user cannot be sure that issues and pull requests will be answered, in particular not the more technical ones.
+The package is expected to work, but we are searching for a maintainer.
+A user cannot be sure that issues and pull requests will be answered, especially more technical ones.
 
 ### Deprecated
 <!-- badge markdown TBD -->
 
-The package is no longer modern, either because it does not work on recent Julia releases, or because it has been superseded by other Julia packages.
-New users should generally look elsewhere.
+The package is no longer recommended, either because it does not work on recent Julia releases, or because it has been superseded by other Julia packages.
+If the package has been superseded, we recommend that its README names the package that replaced it.
 
 ### Using the badges
-To use a badge, place it near the top of your package's README, and copy the markdown for the status that applies.
+Copy the markdown for the status that applies, and place it at the top of your package's README, alongside the CI and documentation badges.
+Each badge links to information on what the status means and how to contribute.
 
-To be eligible for a badge, the repository must live in the [BioJulia](https://github.com/BioJulia), [JuliaHealth](https://github.com/JuliaHealth) or [EcoJulia](https://github.com/EcoJulia) GitHub organization, or in another GitHub organization approved by the BioJulia admins — for example a lab organization.
+To be eligible for a badge, the repository must live in the [BioJulia](https://github.com/BioJulia), [JuliaHealth](https://github.com/JuliaHealth) or [EcoJulia](https://github.com/EcoJulia) GitHub organisation, or in another GitHub organisation approved by [the BioJulia admins](#contact-information), for example a lab organisation.
 Personal repositories are not eligible.
-This is so that the status can be updated by someone else if the maintainer becomes unreachable, for whatever reason.
+This ensures that someone else can update the status if the maintainer becomes unreachable.
 
 ### Changing the status of a package
 Anyone can propose a status change by opening an issue or a pull request on the repository in question.
-If a maintainer is around, the change is simply theirs to make.
+If the package has a reachable maintainer, the decision is theirs.
 
 If no maintainer responds:
-* After roughly **one month** of no response, the status may be changed if there is a compelling reason to do so.
-* After **six months** of no response, the status may be changed without any particular reason.
+* After roughly **one month**, the status may be changed if there is a good reason, for example that the package has stopped working on current Julia releases.
+* After **six months**, the status may be changed without any particular reason.
 
 If a maintainer later reappears, the status can always be changed back.
 
 It is not possible to write down rules that cover every case, so please try to work it out in the spirit of the descriptions above.
-If there is disagreement, the decision of the admins of the organization the repository belongs to should be followed, together with the [BioJulia admins](#contact-information) if the repository is outside BioJulia.
+If there is disagreement, the decision of the admins of the organisation the repository belongs to should be followed, together with the BioJulia admins if the repository is outside BioJulia.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,7 @@ If the BioJulia admins agree to transfer your repo to BioJulia, we will collabor
 ## Package maintenance status
 We recommend that every BioJulia package carries a badge at the top of its README, stating how actively the package is maintained.
 The purpose of the badge is to set expectations: it tells a prospective user whether they can rely on the package, and whether they can expect a response if they open an issue.
+In the future, we may also use the badges to aggregate and promote packages in the BioJulia ecosystem, making them easier to discover.
 
 There are three statuses:
 
@@ -93,21 +94,31 @@ There are three statuses:
 
 At least one person considers themselves an active maintainer of the package.
 A user can expect their issues and pull requests to be answered.
-The badge links to the [BioJulia website](https://biojulia.dev/).
+
+```markdown
+[![BioJulia - Maintained](https://raw.githubusercontent.com/BioJulia/biojulia.github.io/main/badges/biojulia-maintained.svg)](https://biojulia.dev/)
+```
 
 ### Functional; Maintainer needed
-[![BioJulia - Functional; Maintainer needed](https://raw.githubusercontent.com/BioJulia/biojulia.github.io/main/badges/biojulia-functional-maintainer-needed.svg)](https://github.com/BioJulia/Contributing/blob/master/CONTRIBUTING.md)
+[![BioJulia - Functional; Maintainer needed](https://raw.githubusercontent.com/BioJulia/biojulia.github.io/main/badges/biojulia-functional-maintainer-needed.svg)](https://github.com/BioJulia/Contributing/blob/master/CONTRIBUTING.md#becoming-a-package-maintainer)
 
 The package is expected to work, but we are searching for a maintainer.
 A user cannot be sure that issues and pull requests will be answered, especially more technical ones.
-The badge links to these guidelines, since someone clicking it may be interested in maintaining the package.
+The badge links to [Becoming a package maintainer](#becoming-a-package-maintainer), since someone clicking it may be interested in maintaining the package.
+
+```markdown
+[![BioJulia - Functional; Maintainer needed](https://raw.githubusercontent.com/BioJulia/biojulia.github.io/main/badges/biojulia-functional-maintainer-needed.svg)](https://github.com/BioJulia/Contributing/blob/master/CONTRIBUTING.md#becoming-a-package-maintainer)
+```
 
 ### Deprecated
 [![BioJulia - Deprecated](https://raw.githubusercontent.com/BioJulia/biojulia.github.io/main/badges/biojulia-deprecated.svg)](https://biojulia.dev/)
 
 The package is no longer recommended, either because it does not work on recent Julia releases, or because it has been superseded by other Julia packages.
 If the package has been superseded, we recommend that its README names the package that replaced it.
-The badge links to the [BioJulia website](https://biojulia.dev/).
+
+```markdown
+[![BioJulia - Deprecated](https://raw.githubusercontent.com/BioJulia/biojulia.github.io/main/badges/biojulia-deprecated.svg)](https://biojulia.dev/)
+```
 
 ### Using the badges
 Copy the markdown for the status that applies, and place it at the top of your package's README, alongside the CI and documentation badges.
@@ -127,4 +138,4 @@ If no maintainer responds:
 If a maintainer later reappears, the status can always be changed back.
 
 It is not possible to write down rules that cover every case, so please try to work it out in the spirit of the descriptions above.
-If there is disagreement, the decision of the admins of the organisation the repository belongs to should be followed, together with the BioJulia admins if the repository is outside BioJulia.
+If there is disagreement, the decision should be taken by the admins of the organisation the repository belongs to, together with the BioJulia admins if the repository is outside BioJulia.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,21 +89,21 @@ The purpose of the badge is to set expectations: it tells a prospective user whe
 There are three statuses:
 
 ### Maintained
-[![BioJulia - Maintained](https://raw.githubusercontent.com/rasmushenningsson/biojulia.github.io/badges/badges/biojulia-maintained.svg)](https://biojulia.dev/)
+[![BioJulia - Maintained](https://raw.githubusercontent.com/BioJulia/biojulia.github.io/main/badges/biojulia-maintained.svg)](https://biojulia.dev/)
 
 At least one person considers themselves an active maintainer of the package.
 A user can expect their issues and pull requests to be answered.
 The badge links to the [BioJulia website](https://biojulia.dev/).
 
 ### Functional; Maintainer needed
-[![BioJulia - Functional; Maintainer needed](https://raw.githubusercontent.com/rasmushenningsson/biojulia.github.io/badges/badges/biojulia-functional-maintainer-needed.svg)](https://github.com/BioJulia/Contributing/blob/master/CONTRIBUTING.md)
+[![BioJulia - Functional; Maintainer needed](https://raw.githubusercontent.com/BioJulia/biojulia.github.io/main/badges/biojulia-functional-maintainer-needed.svg)](https://github.com/BioJulia/Contributing/blob/master/CONTRIBUTING.md)
 
 The package is expected to work, but we are searching for a maintainer.
 A user cannot be sure that issues and pull requests will be answered, especially more technical ones.
 The badge links to these guidelines, since someone clicking it may be interested in maintaining the package.
 
 ### Deprecated
-[![BioJulia - Deprecated](https://raw.githubusercontent.com/rasmushenningsson/biojulia.github.io/badges/badges/biojulia-deprecated.svg)](https://biojulia.dev/)
+[![BioJulia - Deprecated](https://raw.githubusercontent.com/BioJulia/biojulia.github.io/main/badges/biojulia-deprecated.svg)](https://biojulia.dev/)
 
 The package is no longer recommended, either because it does not work on recent Julia releases, or because it has been superseded by other Julia packages.
 If the package has been superseded, we recommend that its README names the package that replaced it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,26 +89,28 @@ The purpose of the badge is to set expectations: it tells a prospective user whe
 There are three statuses:
 
 ### Maintained
-<!-- badge markdown TBD -->
+[![BioJulia - Maintained](https://raw.githubusercontent.com/rasmushenningsson/biojulia.github.io/badges/badges/biojulia-maintained.svg)](https://biojulia.dev/)
 
 At least one person considers themselves an active maintainer of the package.
 A user can expect their issues and pull requests to be answered.
+The badge links to the [BioJulia website](https://biojulia.dev/).
 
 ### Functional; Maintainer needed
-<!-- badge markdown TBD -->
+[![BioJulia - Functional; Maintainer needed](https://raw.githubusercontent.com/rasmushenningsson/biojulia.github.io/badges/badges/biojulia-functional-maintainer-needed.svg)](https://github.com/BioJulia/Contributing/blob/master/CONTRIBUTING.md)
 
 The package is expected to work, but we are searching for a maintainer.
 A user cannot be sure that issues and pull requests will be answered, especially more technical ones.
+The badge links to these guidelines, since someone clicking it may be interested in maintaining the package.
 
 ### Deprecated
-<!-- badge markdown TBD -->
+[![BioJulia - Deprecated](https://raw.githubusercontent.com/rasmushenningsson/biojulia.github.io/badges/badges/biojulia-deprecated.svg)](https://biojulia.dev/)
 
 The package is no longer recommended, either because it does not work on recent Julia releases, or because it has been superseded by other Julia packages.
 If the package has been superseded, we recommend that its README names the package that replaced it.
+The badge links to the [BioJulia website](https://biojulia.dev/).
 
 ### Using the badges
 Copy the markdown for the status that applies, and place it at the top of your package's README, alongside the CI and documentation badges.
-Each badge links to information on what the status means and how to contribute.
 
 To be eligible for a badge, the repository must live in the [BioJulia](https://github.com/BioJulia), [JuliaHealth](https://github.com/JuliaHealth) or [EcoJulia](https://github.com/EcoJulia) GitHub organisation, or in another GitHub organisation approved by [the BioJulia admins](#contact-information), for example a lab organisation.
 Personal repositories are not eligible.


### PR DESCRIPTION
Add a section in CONTRIBUTING.md on package maintenance status.

This PR should only be merged after https://github.com/BioJulia/biojulia.github.io/pull/42 has been merged, because otherwise the linked badge svg files are not present.

I've tried to make the text match previous discussions. I'm open to changes/improvements.

- [x] I have updated any relevant documentation and docstrings.
- ~[ ] I have added unit tests, and the CodeCov bot shows tests cover my new code.~ Not applicable.
- [x] I have mentioned my changes in the CHANGELOG.md file.